### PR TITLE
Fix compiler runtime workaround

### DIFF
--- a/lib/react-compiler-runtime/index.js
+++ b/lib/react-compiler-runtime/index.js
@@ -1,5 +1,6 @@
 // lib/react-compiler-runtime.js
 const $empty = Symbol.for("react.memo_cache_sentinel");
+const React = require('react');
 /**
  * DANGER: this hook is NEVER meant to be called directly!
  *
@@ -7,7 +8,7 @@ const $empty = Symbol.for("react.memo_cache_sentinel");
  * from React 19. It is not as efficient and may invalidate more frequently
  * than the official API. Please upgrade to React 19 as soon as you can.
  **/
-export function c(size: number) {
+export function c(size) {
   return React.useState(() => {
     const $ = new Array(size);
     for (let ii = 0; ii < size; ii++) {


### PR DESCRIPTION
Fixes https://github.com/expo/react-conf-app/issues/3

We needed to add this workaround in order to open source the app (the production app uses slightly different code here, but it's not OSS so we can't share it). Unforunately, we missed an import.

Apologies if you run into a JS error due to this. After pulling latest, re-install `node-modules` and clear the cache, and it should all work.

```
rm -rf node_modules
yarn
npx expo start --reset-cache
```