### PR TITLE
fix: layout shift with matchContents [do not merge yet]

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -78,7 +78,14 @@ const config: ExpoConfig = {
   owner: EAS_APP_OWNER,
   plugins: [
     "expo-asset",
-    "expo-build-properties",
+    [
+      "expo-build-properties",
+      {
+        ios: {
+          buildReactNativeFromSource: true,
+        },
+      },
+    ],
     "expo-web-browser",
     [
       "expo-quick-actions",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,9 @@
   },
   "patchedDependencies": {
     "react-native-screens@4.16.0": "patches/react-native-screens@4.16.0.patch",
+    "react-native@0.81.4": "patches/react-native@0.81.4.patch",
     "expo-modules-core@3.0.16": "patches/expo-modules-core@3.0.16.patch",
+    "@expo/ui@0.2.0-beta.3": "patches/@expo%2Fui@0.2.0-beta.3.patch",
   },
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
   },
   "patchedDependencies": {
     "expo-modules-core@3.0.16": "patches/expo-modules-core@3.0.16.patch",
-    "react-native-screens@4.16.0": "patches/react-native-screens@4.16.0.patch"
+    "react-native-screens@4.16.0": "patches/react-native-screens@4.16.0.patch",
+    "react-native@0.81.4": "patches/react-native@0.81.4.patch",
+    "@expo/ui@0.2.0-beta.3": "patches/@expo%2Fui@0.2.0-beta.3.patch"
   }
 }

--- a/patches/@expo%2Fui@0.2.0-beta.3.patch
+++ b/patches/@expo%2Fui@0.2.0-beta.3.patch
@@ -1,0 +1,43 @@
+diff --git a/node_modules/@expo/ui/.bun-tag-bf5ba0983fd04869 b/.bun-tag-bf5ba0983fd04869
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@expo/ui/.bun-tag-e64ee9fb6bcfdd15 b/.bun-tag-e64ee9fb6bcfdd15
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/ios/HostView.swift b/ios/HostView.swift
+index cda337c85897bec2d41a5fb9b85b36bfeb9be5cc..4190e80facfb86de63617643be260b14d71b9061 100644
+--- a/ios/HostView.swift
++++ b/ios/HostView.swift
+@@ -20,6 +20,7 @@ internal enum ExpoColorScheme: String, Enumerable {
+ internal final class HostViewProps: ExpoSwiftUI.ViewProps {
+   @Field var useViewportSizeMeasurement: Bool = false
+   @Field var colorScheme: ExpoColorScheme?
++  @Field var matchContents: Bool = false
+   var onLayoutContent = EventDispatcher()
+ }
+ 
+@@ -128,8 +129,12 @@ private struct ViewportSizeMeasurementLayout: Layout {
+  */
+ private struct GeometryChangeModifier: ViewModifier {
+   let props: HostViewProps
++  @EnvironmentObject var shadowNodeProxy: ExpoSwiftUI.ShadowNodeProxy
+ 
+   private func dispatchOnLayoutContent(_ size: CGSize) {
++    if (props.matchContents) {
++      shadowNodeProxy.setViewSize?(size)
++    }
+     props.onLayoutContent([
+       "width": size.width,
+       "height": size.height
+diff --git a/src/swift-ui/Host/index.tsx b/src/swift-ui/Host/index.tsx
+index 1798af6452e290bdfad9fed1b9f4bb4a85066fdd..3018fef5153162776ddc6bf7317e467b175cb025 100644
+--- a/src/swift-ui/Host/index.tsx
++++ b/src/swift-ui/Host/index.tsx
+@@ -65,6 +65,7 @@ export function Host(props: HostProps) {
+           setContainerStyle(newContainerStyle);
+         }
+       }}
++      matchContents={matchContents}
+       {...restProps}
+     />
+   );

--- a/patches/expo-modules-core@3.0.16.patch
+++ b/patches/expo-modules-core@3.0.16.patch
@@ -1,8 +1,14 @@
+diff --git a/node_modules/expo-modules-core/.bun-tag-a8c59a8f16e7ed58 b/.bun-tag-a8c59a8f16e7ed58
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/expo-modules-core/.bun-tag-dcfea0d99e726839 b/.bun-tag-dcfea0d99e726839
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift b/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
-index e814b2f441b2b40a82a39e72128afd39938b2456..1a0c8311604e22aa44e1f3fc405ca0c440db5f97 100644
+index e814b2f441b2b40a82a39e72128afd39938b2456..70ce4a01f1b89cbbb7fc2f1f67f3096f62e4b4ae 100644
 --- a/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
 +++ b/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
-@@ -179,26 +179,15 @@ extension ExpoSwiftUI {
+@@ -179,26 +179,16 @@ extension ExpoSwiftUI {
      }
  #endif // RCT_NEW_ARCH_ENABLED
  
@@ -26,6 +32,7 @@ index e814b2f441b2b40a82a39e72128afd39938b2456..1a0c8311604e22aa44e1f3fc405ca0c4
 -        view.rightAnchor.constraint(equalTo: rightAnchor)
 -      ])
 +      view.frame = self.bounds
++      view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
      }
  
 -    // MARK: - UIView lifecycle
@@ -33,7 +40,7 @@ index e814b2f441b2b40a82a39e72128afd39938b2456..1a0c8311604e22aa44e1f3fc405ca0c4
      public override func didMoveToWindow() {
        super.didMoveToWindow()
  
-@@ -216,7 +205,6 @@ extension ExpoSwiftUI {
+@@ -216,7 +206,6 @@ extension ExpoSwiftUI {
          #if os(iOS) || os(tvOS)
          hostingController.didMove(toParent: parentController)
          #endif
@@ -41,3 +48,16 @@ index e814b2f441b2b40a82a39e72128afd39938b2456..1a0c8311604e22aa44e1f3fc405ca0c4
        } else {
          hostingController.view.removeFromSuperview()
          hostingController.removeFromParent()
+diff --git a/ios/Fabric/ExpoFabricViewObjC.mm b/ios/Fabric/ExpoFabricViewObjC.mm
+index cb64efd25912fda87b2f205349ba1216a2562528..9bdb717928949ef895595e9b9725f76cd9e4fccb 100644
+--- a/ios/Fabric/ExpoFabricViewObjC.mm
++++ b/ios/Fabric/ExpoFabricViewObjC.mm
+@@ -169,7 +169,7 @@ - (void)viewDidUpdateProps
+ - (void)setShadowNodeSize:(float)width height:(float)height
+ {
+   if (_state) {
+-    _state->updateState(ExpoViewState(width,height));
++    _state->updateState(ExpoViewState(width,height), true);
+   }
+ }
+ 

--- a/patches/react-native@0.81.4.patch
+++ b/patches/react-native@0.81.4.patch
@@ -1,0 +1,135 @@
+diff --git a/ReactCommon/react/renderer/core/ConcreteState.h b/ReactCommon/react/renderer/core/ConcreteState.h
+index f0eb03a8666939d58527d8d81e8b29ec91c17403..a8dc5e36c73014bec201b1eb901787ac0aabfa3e 100644
+--- a/ReactCommon/react/renderer/core/ConcreteState.h
++++ b/ReactCommon/react/renderer/core/ConcreteState.h
+@@ -74,10 +74,10 @@ class ConcreteState : public State {
+    * function for cases where a new value of data does not depend on an old
+    * value.
+    */
+-  void updateState(Data&& newData) const {
++  void updateState(Data&& newData, bool flushSync = false) const {
+     updateState([data{std::move(newData)}](const Data& oldData) -> SharedData {
+       return std::make_shared<const Data>(data);
+-    });
++    }, flushSync);
+   }
+ 
+   /*
+@@ -89,7 +89,7 @@ class ConcreteState : public State {
+    * return `nullptr`.
+    */
+   void updateState(
+-      std::function<StateData::Shared(const Data& oldData)> callback) const {
++      std::function<StateData::Shared(const Data& oldData)> callback, bool flushSync = false) const {
+     auto family = family_.lock();
+ 
+     if (!family) {
+@@ -104,7 +104,7 @@ class ConcreteState : public State {
+           return callback(*static_cast<const Data*>(oldData.get()));
+         }};
+ 
+-    family->dispatchRawState(std::move(stateUpdate));
++    family->dispatchRawState(std::move(stateUpdate), flushSync);
+   }
+ 
+ #if defined(RN_SERIALIZABLE_STATE)
+diff --git a/ReactCommon/react/renderer/core/EventDispatcher.cpp b/ReactCommon/react/renderer/core/EventDispatcher.cpp
+index 8d5476b2137b68af19b8f26e1618814f16cffe99..e0a824e581a8fce847df0d26589a711b00575e84 100644
+--- a/ReactCommon/react/renderer/core/EventDispatcher.cpp
++++ b/ReactCommon/react/renderer/core/EventDispatcher.cpp
+@@ -41,8 +41,8 @@ void EventDispatcher::experimental_flushSync() const {
+   eventQueue_.experimental_flushSync();
+ }
+ 
+-void EventDispatcher::dispatchStateUpdate(StateUpdate&& stateUpdate) const {
+-  eventQueue_.enqueueStateUpdate(std::move(stateUpdate));
++void EventDispatcher::dispatchStateUpdate(StateUpdate&& stateUpdate, bool flushSync) const {
++  eventQueue_.enqueueStateUpdate(std::move(stateUpdate), flushSync);
+ }
+ 
+ void EventDispatcher::dispatchUniqueEvent(RawEvent&& rawEvent) const {
+diff --git a/ReactCommon/react/renderer/core/EventDispatcher.h b/ReactCommon/react/renderer/core/EventDispatcher.h
+index c103e48982282128f5f5a981493426bae2a304e7..f2867fa1955c7d034fe9ada3c406fd598832154e 100644
+--- a/ReactCommon/react/renderer/core/EventDispatcher.h
++++ b/ReactCommon/react/renderer/core/EventDispatcher.h
+@@ -56,7 +56,7 @@ class EventDispatcher {
+   /*
+    * Dispatches a state update with given priority.
+    */
+-  void dispatchStateUpdate(StateUpdate&& stateUpdate) const;
++  void dispatchStateUpdate(StateUpdate&& stateUpdate, bool flushSync) const;
+ 
+ #pragma mark - Event listeners
+   /*
+diff --git a/ReactCommon/react/renderer/core/EventQueue.cpp b/ReactCommon/react/renderer/core/EventQueue.cpp
+index a83c805287c4d75e636058a3b5a11708a2940f35..5bc0991cf97315458f5540c0178fe0c5622140af 100644
+--- a/ReactCommon/react/renderer/core/EventQueue.cpp
++++ b/ReactCommon/react/renderer/core/EventQueue.cpp
+@@ -65,7 +65,7 @@ void EventQueue::enqueueUniqueEvent(RawEvent&& rawEvent) const {
+   enqueueEvent(std::move(rawEvent));
+ }
+ 
+-void EventQueue::enqueueStateUpdate(StateUpdate&& stateUpdate) const {
++void EventQueue::enqueueStateUpdate(StateUpdate&& stateUpdate, bool flushSync) const {
+   {
+     std::scoped_lock lock(queueMutex_);
+     if (!stateUpdateQueue_.empty()) {
+@@ -77,7 +77,11 @@ void EventQueue::enqueueStateUpdate(StateUpdate&& stateUpdate) const {
+     stateUpdateQueue_.push_back(std::move(stateUpdate));
+   }
+ 
+-  onEnqueue();
++  if (flushSync) {
++    flushStateUpdates();
++  } else {
++    onEnqueue();
++  }
+ }
+ 
+ void EventQueue::onEnqueue() const {
+diff --git a/ReactCommon/react/renderer/core/EventQueue.h b/ReactCommon/react/renderer/core/EventQueue.h
+index 74525c6971a3a4be4f5ec3df335c777f929fefe7..f66b5345c7d8ee67abfe5d449b614321dc2d5493 100644
+--- a/ReactCommon/react/renderer/core/EventQueue.h
++++ b/ReactCommon/react/renderer/core/EventQueue.h
+@@ -46,7 +46,7 @@ class EventQueue {
+    * Enqueues and (probably later) dispatch a given state update.
+    * Can be called on any thread.
+    */
+-  void enqueueStateUpdate(StateUpdate&& stateUpdate) const;
++  void enqueueStateUpdate(StateUpdate&& stateUpdate, bool flushSync) const;
+ 
+   /*
+    * Experimental API exposed to support EventEmitter::experimental_flushSync.
+diff --git a/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp b/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+index bf486802ccabc4f039c80f726da57488d0c9d36e..e99e27dd8b16251eafabffba540988ec7509bedf 100644
+--- a/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
++++ b/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+@@ -173,13 +173,13 @@ std::shared_ptr<const State> ShadowNodeFamily::getMostRecentStateIfObsolete(
+   return mostRecentState_;
+ }
+ 
+-void ShadowNodeFamily::dispatchRawState(StateUpdate&& stateUpdate) const {
++void ShadowNodeFamily::dispatchRawState(StateUpdate&& stateUpdate, bool flushSync) const {
+   auto eventDispatcher = eventDispatcher_.lock();
+   if (!eventDispatcher) {
+     return;
+   }
+ 
+-  eventDispatcher->dispatchStateUpdate(std::move(stateUpdate));
++  eventDispatcher->dispatchStateUpdate(std::move(stateUpdate), flushSync);
+ }
+ 
+ } // namespace facebook::react
+diff --git a/ReactCommon/react/renderer/core/ShadowNodeFamily.h b/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+index 838560895287555db717f615e39f156d0eca41c7..afaf066af80ed91d6eaac1fdce458190e30d0cdc 100644
+--- a/ReactCommon/react/renderer/core/ShadowNodeFamily.h
++++ b/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+@@ -108,7 +108,7 @@ class ShadowNodeFamily final : public jsi::NativeState {
+   /*
+    * Dispatches a state update with given priority.
+    */
+-  void dispatchRawState(StateUpdate&& stateUpdate) const;
++  void dispatchRawState(StateUpdate&& stateUpdate, bool flushSync) const;
+ 
+   /*
+    * Holds currently applied native props. `nullptr` if setNativeProps API is

--- a/src/components/HeaderButtons/HeaderButton.ios.tsx
+++ b/src/components/HeaderButtons/HeaderButton.ios.tsx
@@ -16,7 +16,7 @@ export interface HeaderButtonProps {
 
 export function HeaderButton({ imageProps, buttonProps }: HeaderButtonProps) {
   return (
-    <Host matchContents style={{ height: SIZE, width: SIZE }}>
+    <Host matchContents>
       <Button {...buttonProps} variant={buttonProps?.variant || "glass"}>
         <Image
           {...imageProps}

--- a/src/components/TimeZoneSwitch.ios.tsx
+++ b/src/components/TimeZoneSwitch.ios.tsx
@@ -7,7 +7,7 @@ export function TimeZoneSwitch() {
   const toggleLocalTz = useReactConfStore((state) => state.toggleLocalTz);
 
   return (
-    <Host style={{ width: 33, height: 44 }}>
+    <Host matchContents>
       <ContextMenu>
         <ContextMenu.Items>
           <Picker


### PR DESCRIPTION
## Issue
`matchContents` can lead to layout shift due to async size update of Host component.

### Before

https://github.com/user-attachments/assets/b13f9ea0-0243-42b5-b22d-a0a36e274a6f

### After

https://github.com/user-attachments/assets/b0e14d5b-94ab-49b2-9f1d-0da5d0a1968d



## Solution

Update size using native state, however this still won't fix the issue since the native state is also async. So this PR adds this [patch](https://github.com/facebook/react-native/pull/51741/) to allow sync updates to RN's native state. The feature was added by meta [here](https://github.com/facebook/react-native/pull/52604) and it will be [released in 0.82 nightly](https://exponent-internal.slack.com/archives/CGHFEK33M/p1756317138912409?thread_ts=1756313263.833789&cid=CGHFEK33M). For now we can use the patch.

## Notes

Patch here changes the Host component's matchContents behaviour, current behaviour merges user passed styles and host styles. I am not sure why someone would need to use matchContents + custom dimension together.
