### PR TITLE
Fix secondary text color which is harder to read

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,7 +15,7 @@ export const theme = {
       dark: "rgba(0,0,0,0)",
     },
     text: { light: "#121212", dark: "#FFFFFF" },
-    textSecondary: { light: "#808080", dark: "#808080" },
+    textSecondary: { light: "#808080", dark: "#CCCCCC" },
     background: { light: "#FFFFFF", dark: "#000000" },
     backgroundSecondary: {
       light: "#f1f1f1",


### PR DESCRIPTION
I'm getting feedback from the team that the secondary text is too hard to read on dark theme. I'm tweaking it a bit here:

| Before | After |
| -- | -- |
| <img width="480" height="800" alt="Screenshot_1758872711" src="https://github.com/user-attachments/assets/fc9d8122-cccd-420c-afd8-fe1667ba11e0" /> | <img width="480" height="800" alt="Screenshot_1758872705" src="https://github.com/user-attachments/assets/1ea55202-69d1-4c08-8b61-137960b2999b" /> | 
