### PR TITLE
Fix timezone switcher for iOS 26

### DIFF
--- a/src/components/TimeZoneSwitch.ios.tsx
+++ b/src/components/TimeZoneSwitch.ios.tsx
@@ -1,8 +1,11 @@
 import { useReactConfStore } from "@/store/reactConfStore";
+import { theme } from "@/theme";
 import { getCurrentTimezone } from "@/utils/formatDate";
 
 import { Button, ContextMenu, Host, Picker } from "@expo/ui/swift-ui";
 import * as Haptics from "expo-haptics";
+import { useThemeColor } from "./Themed";
+import { isLiquidGlassAvailable } from "expo-glass-effect";
 
 const options = ["PDT (Venue)", `${getCurrentTimezone()} (Local)`];
 
@@ -18,6 +21,7 @@ export function TimeZoneSwitch() {
       toggleLocalTz();
     }
   };
+  const color = useThemeColor(theme.color.reactBlue);
 
   return (
     <Host style={{ width: 33, height: 44 }}>
@@ -32,7 +36,11 @@ export function TimeZoneSwitch() {
           />
         </ContextMenu.Items>
         <ContextMenu.Trigger>
-          <Button variant="glass" systemImage="globe" />
+          <Button
+            variant={isLiquidGlassAvailable() ? "glass" : "bordered"}
+            systemImage="globe"
+            color={color}
+          />
         </ContextMenu.Trigger>
       </ContextMenu>
     </Host>

--- a/src/components/TimeZoneSwitch.ios.tsx
+++ b/src/components/TimeZoneSwitch.ios.tsx
@@ -1,19 +1,34 @@
 import { useReactConfStore } from "@/store/reactConfStore";
+import { getCurrentTimezone } from "@/utils/formatDate";
 
 import { Button, ContextMenu, Host, Picker } from "@expo/ui/swift-ui";
+import * as Haptics from "expo-haptics";
+
+const options = ["PDT (Venue)", `${getCurrentTimezone()} (Local)`];
 
 export function TimeZoneSwitch() {
   const shouldUseLocalTz = useReactConfStore((state) => state.shouldUseLocalTz);
   const toggleLocalTz = useReactConfStore((state) => state.toggleLocalTz);
+
+  const selectedIndex = shouldUseLocalTz ? 1 : 0;
+
+  const handleToggleLocalTz = (newIndex: number) => {
+    if (selectedIndex !== newIndex) {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      toggleLocalTz();
+    }
+  };
 
   return (
     <Host style={{ width: 33, height: 44 }}>
       <ContextMenu>
         <ContextMenu.Items>
           <Picker
-            options={["PDT", "PST"]}
-            selectedIndex={shouldUseLocalTz ? 0 : 1}
-            onOptionSelected={({ nativeEvent: { index } }) => toggleLocalTz()}
+            selectedIndex={selectedIndex}
+            options={options}
+            onOptionSelected={({ nativeEvent: { index } }) =>
+              handleToggleLocalTz(index)
+            }
           />
         </ContextMenu.Items>
         <ContextMenu.Trigger>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -10,6 +10,10 @@ export const theme = {
   colorReactDarkBlue: "#087EA4",
 
   color: {
+    reactBlue: {
+      light: "#58C4DC",
+      dark: "#087EA4",
+    },
     transparent: {
       light: "rgba(255,255,255,0)",
       dark: "rgba(0,0,0,0)",


### PR DESCRIPTION
## Why

Resolves ENG-17542

- [x] ensure we switch between local and venue tz
- [x] use a styled button for iOS 18