### PR TITLE
Improve tab bar colors

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -7,12 +7,17 @@ import {
   VectorIcon,
 } from "expo-router/unstable-native-tabs";
 import React from "react";
-import { ColorValue, ImageSourcePropType, Platform } from "react-native";
+import {
+  ColorValue,
+  ImageSourcePropType,
+  Platform,
+  DynamicColorIOS,
+} from "react-native";
 
-import { useThemeColor } from "@/components/Themed";
 import { theme } from "@/theme";
 import { useBookmarkStore } from "@/store/bookmarkStore";
 import { isLiquidGlassAvailable } from "expo-glass-effect";
+import { useThemeColor } from "@/components/Themed";
 
 // Todo (betomoedano): In the future we can remove this type. Learn more: https://exponent-internal.slack.com/archives/C0447EFTS74/p1758042759724779?thread_ts=1758039375.241799&cid=C0447EFTS74
 type VectorIconFamily = {
@@ -24,37 +29,40 @@ type VectorIconFamily = {
 };
 
 export default function TabLayout() {
-  const tabBarBackgroundColor = useThemeColor(theme.color.background);
+  const bookmarks = useBookmarkStore((state) => state.bookmarks);
+  const hasBookmarks = bookmarks.length > 0;
   const tintColor = useThemeColor(theme.color.reactBlue);
-
+  const androidInactiveTintColor = useThemeColor({
+    light: theme.colorGrey,
+    dark: "#FFFFFF50",
+  });
   const tabBarActiveTintColor = useThemeColor({
     light: theme.colorBlack,
     dark: theme.colorWhite,
   });
 
-  const tabBarInactiveTintColor = useThemeColor({
-    light: theme.colorGrey,
-    dark: "#FFFFFF50",
-  });
-
-  const bookmarks = useBookmarkStore((state) => state.bookmarks);
-  const hasBookmarks = bookmarks.length > 0;
-
   return (
     <NativeTabs
-      tintColor={tabBarActiveTintColor}
-      backgroundColor={tabBarBackgroundColor}
-      labelVisibilityMode="labeled"
-      iconColor={tabBarInactiveTintColor}
-      indicatorColor={tintColor + "20"}
       labelStyle={{
-        color: tabBarInactiveTintColor,
+        color: Platform.OS === "ios" ? undefined : androidInactiveTintColor,
       }}
+      iconColor={
+        Platform.OS === "ios"
+          ? DynamicColorIOS(theme.color.reactBlue)
+          : androidInactiveTintColor
+      }
+      tintColor={
+        Platform.OS === "ios"
+          ? DynamicColorIOS(theme.color.reactBlue)
+          : tabBarActiveTintColor
+      }
+      labelVisibilityMode="labeled"
+      indicatorColor={tintColor + "25"}
       disableTransparentOnScrollEdge={true} // Used to prevent transparent background on iOS 18 and older
     >
       <NativeTabs.Trigger name="(calendar)">
         {Platform.select({
-          ios: <Icon sf="calendar" selectedColor={tabBarActiveTintColor} />,
+          ios: <Icon sf="calendar" />,
           android: (
             <Icon
               src={
@@ -71,7 +79,7 @@ export default function TabLayout() {
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="bookmarks">
         {Platform.select({
-          ios: <Icon sf="bookmark" selectedColor={tabBarActiveTintColor} />,
+          ios: <Icon sf="bookmark" />,
           android: (
             <Icon
               src={
@@ -96,7 +104,7 @@ export default function TabLayout() {
         role={isLiquidGlassAvailable() ? "search" : undefined}
       >
         {Platform.select({
-          ios: <Icon sf="person.2" selectedColor={tabBarActiveTintColor} />,
+          ios: <Icon sf="person.2" />,
           android: (
             <Icon
               src={
@@ -113,7 +121,7 @@ export default function TabLayout() {
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="info">
         {Platform.select({
-          ios: <Icon sf="map" selectedColor={tabBarActiveTintColor} />,
+          ios: <Icon sf="map" />,
           android: (
             <Icon
               src={
@@ -126,6 +134,7 @@ export default function TabLayout() {
             />
           ),
         })}
+        <Label>Info</Label>
       </NativeTabs.Trigger>
     </NativeTabs>
   );

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -32,7 +32,11 @@ export default function TabLayout() {
   const bookmarks = useBookmarkStore((state) => state.bookmarks);
   const hasBookmarks = bookmarks.length > 0;
   const tintColor = useThemeColor(theme.color.reactBlue);
-  const androidInactiveTintColor = useThemeColor({
+  const tintColorInvert = useThemeColor({
+    light: theme.color.reactBlue.dark,
+    dark: theme.color.reactBlue.light,
+  });
+  const inactiveTintColor = useThemeColor({
     light: theme.colorGrey,
     dark: "#FFFFFF50",
   });
@@ -41,15 +45,24 @@ export default function TabLayout() {
     dark: theme.colorWhite,
   });
 
+  const labelSelectedStyle =
+    Platform.OS === "ios" ? { color: tintColorInvert } : undefined;
+
   return (
     <NativeTabs
       labelStyle={{
-        color: Platform.OS === "ios" ? undefined : androidInactiveTintColor,
+        color:
+          Platform.OS === "ios"
+            ? DynamicColorIOS({
+                light: theme.colorBlack,
+                dark: theme.colorWhite,
+              })
+            : inactiveTintColor,
       }}
       iconColor={
         Platform.OS === "ios"
           ? DynamicColorIOS(theme.color.reactBlue)
-          : androidInactiveTintColor
+          : inactiveTintColor
       }
       tintColor={
         Platform.OS === "ios"
@@ -75,7 +88,7 @@ export default function TabLayout() {
             />
           ),
         })}
-        <Label>Calendar</Label>
+        <Label selectedStyle={labelSelectedStyle}>Calendar</Label>
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="bookmarks">
         {Platform.select({
@@ -92,7 +105,7 @@ export default function TabLayout() {
             />
           ),
         })}
-        <Label>Bookmarked</Label>
+        <Label selectedStyle={labelSelectedStyle}>Bookmarked</Label>
         {hasBookmarks && !isLiquidGlassAvailable() && (
           <Badge selectedBackgroundColor={tintColor}>
             {bookmarks.length.toString()}
@@ -117,7 +130,7 @@ export default function TabLayout() {
             />
           ),
         })}
-        <Label>Speakers</Label>
+        <Label selectedStyle={labelSelectedStyle}>Speakers</Label>
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="info">
         {Platform.select({
@@ -134,7 +147,7 @@ export default function TabLayout() {
             />
           ),
         })}
-        <Label>Info</Label>
+        <Label selectedStyle={labelSelectedStyle}>Info</Label>
       </NativeTabs.Trigger>
     </NativeTabs>
   );

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -32,10 +32,6 @@ export default function TabLayout() {
   const bookmarks = useBookmarkStore((state) => state.bookmarks);
   const hasBookmarks = bookmarks.length > 0;
   const tintColor = useThemeColor(theme.color.reactBlue);
-  const tintColorInvert = useThemeColor({
-    light: theme.color.reactBlue.dark,
-    dark: theme.color.reactBlue.light,
-  });
   const inactiveTintColor = useThemeColor({
     light: theme.colorGrey,
     dark: "#FFFFFF50",
@@ -46,7 +42,7 @@ export default function TabLayout() {
   });
 
   const labelSelectedStyle =
-    Platform.OS === "ios" ? { color: tintColorInvert } : undefined;
+    Platform.OS === "ios" ? { color: tintColor } : undefined;
 
   return (
     <NativeTabs

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,8 +9,8 @@ export const theme = {
 
   color: {
     reactBlue: {
-      light: "#58C4DC",
-      dark: "#087EA4",
+      light: "#087EA4",
+      dark: "#58C4DC",
     },
     transparent: {
       light: "rgba(255,255,255,0)",


### PR DESCRIPTION
## Why

Use `DynamicColorIOS` to ensure liquid glass bottom tabs work nicely in dark mode when the content is light.

I also inverted the colos for "light" and "dark" react blue so we show the lighter color in dark mode.

| Before      | After |
| ----------- | ----------- |
| <img width="399" height="918" alt="Screenshot 2025-09-29 at 12 34 17" src="https://github.com/user-attachments/assets/5b11b4d2-9491-4f8f-a175-ff6ec47224be" />      | <img width="399" height="918" alt="Screenshot 2025-09-29 at 12 45 23" src="https://github.com/user-attachments/assets/cd60ab60-e246-4181-ad09-d471d593a947" />       |




I also changed the highlight color for the bottom tabs to be the React blue

| Light      | Dark |
| ----------- | ----------- |
| <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2025-09-29 at 12 35 51" src="https://github.com/user-attachments/assets/e486c0b2-e4a0-4c42-ac0d-acb8fe072670" />      | <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2025-09-29 at 12 35 48" src="https://github.com/user-attachments/assets/5a11a88a-3e76-49f5-b572-71b5d38df096" />       |




