### PR TITLE
Prevent onPress getting called on-scroll

### DIFF
--- a/src/components/TalkCard.tsx
+++ b/src/components/TalkCard.tsx
@@ -40,22 +40,30 @@ export function TalkCard({ session, day, isBookmarked = false }: Props) {
   };
 
   return (
-    <Pressable onPress={handlePress}>
-      <ThemedView style={styles.container}>
-        {!isBookmarked && (
-          <ThemedText
-            fontSize={18}
-            fontWeight="medium"
-            color={theme.color.textSecondary}
-            marginBottom={theme.space8}
-            style={{ marginLeft: theme.space24 }}
-          >
-            {formatSessionTime(session, shouldUseLocalTz)}
-          </ThemedText>
-        )}
-        <ThemedView
-          color={theme.color.backgroundSecondary}
-          style={styles.content}
+    <ThemedView style={styles.container}>
+      {!isBookmarked && (
+        <ThemedText
+          fontSize={18}
+          fontWeight="medium"
+          color={theme.color.textSecondary}
+          marginBottom={theme.space8}
+          style={{ marginLeft: theme.space24 }}
+        >
+          {formatSessionTime(session, shouldUseLocalTz)}
+        </ThemedText>
+      )}
+      <ThemedView
+        color={theme.color.backgroundSecondary}
+        style={styles.content}
+      >
+        <Pressable
+          onPress={handlePress}
+          style={{
+            marginHorizontal: -theme.space16,
+            paddingHorizontal: theme.space16,
+            marginVertical: -theme.space8,
+            paddingVertical: theme.space8,
+          }}
         >
           <View style={styles.titleAndBookmark}>
             <ThemedText fontSize={18} fontWeight="semiBold" style={{ flex: 1 }}>
@@ -79,25 +87,25 @@ export function TalkCard({ session, day, isBookmarked = false }: Props) {
               </ThemedText>
             </ThemedView>
           )}
-          {session.speakers.map((speaker) => (
-            <Pressable
-              onPress={() => handleSpeakerPress(speaker)}
-              key={speaker.id}
-              style={({ pressed }) => ({
-                marginHorizontal: -theme.space16,
-                paddingHorizontal: theme.space16,
-                marginVertical: -theme.space8,
-                paddingVertical: theme.space8,
-                borderRadius: theme.borderRadius32,
-                opacity: pressed ? 0.6 : 1,
-              })}
-            >
-              <SpeakerDetails speaker={speaker} key={speaker.id} />
-            </Pressable>
-          ))}
-        </ThemedView>
+        </Pressable>
+        {session.speakers.map((speaker) => (
+          <Pressable
+            onPress={() => handleSpeakerPress(speaker)}
+            key={speaker.id}
+            style={({ pressed }) => ({
+              marginHorizontal: -theme.space16,
+              paddingHorizontal: theme.space16,
+              marginVertical: -theme.space8,
+              paddingVertical: theme.space8,
+              borderRadius: theme.borderRadius32,
+              opacity: pressed ? 0.6 : 1,
+            })}
+          >
+            <SpeakerDetails speaker={speaker} key={speaker.id} />
+          </Pressable>
+        ))}
       </ThemedView>
-    </Pressable>
+    </ThemedView>
   );
 }
 


### PR DESCRIPTION
## Why

https://exponent-internal.slack.com/archives/CGHFEK33M/p1759144142364909?thread_ts=1759137676.383699&cid=CGHFEK33M

We were correctly using `Pressable` and `FlatList` from `react-native-gesture-handler`, but because the pressable areas overlapped, it wasn't working correctly.

| Before      | After |
| ----------- | ----------- |
| <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2025-09-29 at 14 24 40" src="https://github.com/user-attachments/assets/a1388156-1864-489a-8595-7fbecaff1658" />      | <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2025-09-29 at 14 21 02" src="https://github.com/user-attachments/assets/e3365de2-0ac5-4e74-b974-35a1f9c46616" />       |



