### PR TITLE
[Android] use keyboard layout "pan"

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -66,6 +66,7 @@ const config: ExpoConfig = {
     userInterfaceStyle: "automatic",
     package: getAppId(),
     edgeToEdgeEnabled: true,
+    softwareKeyboardLayoutMode: "pan",
   },
   web: {
     favicon: "./assets/favicon.png",


### PR DESCRIPTION
## Why

Prevents bottom tabs to be display above the keyboard when searching a speaker.

| Before      | After |
| ----------- | ----------- |
|    <img width="1080" height="2400" alt="Screenshot_20251001-093435" src="https://github.com/user-attachments/assets/3abf6683-57c8-4484-a3f2-4da59440958f" />  |      <img width="1080" height="2400" alt="Screenshot_20251001-093528" src="https://github.com/user-attachments/assets/4e4c17a0-4a2c-40e7-a390-86ea2013736b" />  |
