### PR TITLE
Improve scroll perf by reducing cross-thread communication on scroll

### DIFF
--- a/src/app/(tabs)/(calendar)/index.tsx
+++ b/src/app/(tabs)/(calendar)/index.tsx
@@ -9,6 +9,7 @@ import Animated, {
   useSharedValue,
   interpolate,
   Extrapolation,
+  useAnimatedReaction,
 } from "react-native-reanimated";
 
 import { ActivityCard } from "@/components/ActivityCard";
@@ -47,8 +48,8 @@ export default function Schedule() {
   const animatedTranslateY = useSharedValue(0);
   const animatedPaddingTop = useSharedValue(0);
 
-  const updateIsScrolledDown = useCallback((offsetY: number) => {
-    isScrolledDown.current = offsetY > 10;
+  const updateIsScrolledDown = useCallback((isScrolled: boolean) => {
+    isScrolledDown.current = isScrolled;
   }, []);
 
   const scrollHandler = useAnimatedScrollHandler((event) => {
@@ -60,9 +61,16 @@ export default function Schedule() {
       [0, HEADER_SCROLL_OFFSET],
       Extrapolation.CLAMP,
     );
-
-    scheduleOnRN(updateIsScrolledDown, event.contentOffset.y);
   });
+
+  useAnimatedReaction(
+    () => translationY.value > 10,
+    (isScrolled, wasScrolled) => {
+      if (isScrolled !== wasScrolled) {
+        scheduleOnRN(updateIsScrolledDown, isScrolled);
+      }
+    },
+  );
 
   const stickyHeaderStyle = useAnimatedStyle(() => {
     if (Platform.OS !== "ios") {


### PR DESCRIPTION
Currently, a JS function is called from the UI thread for every scroll event. This is super inefficient and since we're literally just setting a boolean, the overwhelming majority of these calls do absolutely nothing. I've added a log to the JS function:

https://github.com/user-attachments/assets/d7549d98-f51e-47d8-aaf7-44a06e9c7e02

Simple fix is to only call the function across threads when you need to. This is pretty trivial using `useAnimatedReaction`

https://github.com/user-attachments/assets/bb8b7cec-c2b1-4308-a669-e90ad0b08c4b

