### PR TITLE
Enable reanimated/rn feature flags to allow accurate scroll events tracking

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -79,7 +79,17 @@ const config: ExpoConfig = {
   owner: EAS_APP_OWNER,
   plugins: [
     "expo-asset",
-    "expo-build-properties",
+    [
+      "expo-build-properties",
+      {
+        android: {
+          reactNativeReleaseLevel: "experimental",
+        },
+        ios: {
+          reactNativeReleaseLevel: "experimental",
+        },
+      },
+    ],
     "expo-web-browser",
     "expo-router",
     [

--- a/package.json
+++ b/package.json
@@ -87,5 +87,10 @@
     "react-native-screens@4.16.0": "patches/react-native-screens@4.16.0.patch",
     "expo-router@6.0.6": "patches/expo-router@6.0.6.patch",
     "@expo/ui@0.2.0-beta.3": "patches/@expo%2Fui@0.2.0-beta.3.patch"
+  },
+  "reanimated": {
+    "staticFeatureFlags": {
+      "DISABLE_COMMIT_PAUSING_MECHANISM": true
+    }
   }
 }

--- a/src/app/(tabs)/(calendar)/index.tsx
+++ b/src/app/(tabs)/(calendar)/index.tsx
@@ -50,6 +50,8 @@ export default function Schedule() {
       [0, HEADER_SCROLL_OFFSET],
       Extrapolation.CLAMP,
     );
+
+    isScrolledDown.value = event.contentOffset.y > 10;
   });
 
   const stickyHeaderStyle = useAnimatedStyle(() => {

--- a/src/app/(tabs)/(calendar)/index.tsx
+++ b/src/app/(tabs)/(calendar)/index.tsx
@@ -28,7 +28,7 @@ import {
   type CurrentlyLiveSession,
 } from "@/components/CurrentlyLive";
 
-const AnimatedFlatList = Animated.createAnimatedComponent(FlatList) as FlatList;
+const AnimatedFlatList = Animated.FlatList;
 
 const HEADER_SCROLL_OFFSET = isLiquidGlassAvailable() ? 110 : 90;
 
@@ -50,8 +50,6 @@ export default function Schedule() {
       [0, HEADER_SCROLL_OFFSET],
       Extrapolation.CLAMP,
     );
-
-    isScrolledDown.value = event.contentOffset.y > 10;
   });
 
   const stickyHeaderStyle = useAnimatedStyle(() => {


### PR DESCRIPTION
This PR fixes an issue with the sticky day selector jumping intermittently when scrolling past the top position of the selector.

One change is to use `Animated.FlatList` component as opposed to creating one using `Animated.createAnimatedComponent`. The version that reanimated exports has the throttling defaults set properly such that it avoids event throttling.

In addition, we enable feature flags in react native and reanimated that results in the direct ui thread updates from being delayed. Read more here: https://docs.swmansion.com/react-native-reanimated/docs/guides/feature-flags/#disable_commit_pausing_mechanism
