### PR TITLE
Align headline and text vertically in the layout

### DIFF
--- a/src/app/(tabs)/bookmarks/index.tsx
+++ b/src/app/(tabs)/bookmarks/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Platform, StyleSheet, View } from "react-native";
+import { Platform, Pressable, StyleSheet, View } from "react-native";
 
 import { ThemedText, useThemeColor } from "@/components/Themed";
 import { theme } from "@/theme";
@@ -13,6 +13,7 @@ import Animated, {
   FadeOut,
   LinearTransition,
 } from "react-native-reanimated";
+import { Link } from "expo-router";
 
 export default function Bookmarks() {
   const bookmarks = useBookmarkStore((state) => state.bookmarks);
@@ -53,17 +54,26 @@ export default function Bookmarks() {
       ListEmptyComponent={
         <Animated.View entering={FadeIn} exiting={FadeOut}>
           <View style={styles.bookmarks}>
-            <ThemedText
-              fontWeight="bold"
-              fontSize={theme.fontSize20}
-              style={{ marginBottom: theme.space8 }}
-            >
+            <ThemedText fontWeight="bold" fontSize={theme.fontSize20}>
               No sessions bookmarked
             </ThemedText>
-            <ThemedText fontSize={theme.fontSize18}>
+            <ThemedText
+              fontSize={theme.fontSize18}
+              color={theme.color.textSecondary}
+            >
               Tap on the bookmark icon on a session to add it to your bookmarks,
               and it will be displayed here.
             </ThemedText>
+            <Link href="/(tabs)/(calendar)" asChild>
+              <Pressable>
+                <ThemedText
+                  color={theme.color.reactBlue}
+                  style={{ marginTop: theme.space2 }}
+                >
+                  View all sessions
+                </ThemedText>
+              </Pressable>
+            </Link>
           </View>
         </Animated.View>
       }
@@ -73,7 +83,8 @@ export default function Bookmarks() {
 
 const styles = StyleSheet.create({
   bookmarks: {
-    paddingHorizontal: theme.space24,
+    gap: theme.space16,
+    paddingHorizontal: theme.space16,
   },
   flatListContainer: {
     paddingBottom: Platform.select({ android: 100, default: 0 }),

--- a/src/app/talk/[talkId].tsx
+++ b/src/app/talk/[talkId].tsx
@@ -209,7 +209,10 @@ export default function TalkDetail() {
             {
               minHeight: drawerHeight,
               paddingBottom: insets.bottom + theme.space24,
-              paddingTop: Platform.OS === "ios" ? theme.space24 : undefined,
+              paddingTop: Platform.select({
+                ios: theme.space24,
+                default: undefined,
+              }),
             },
           ]}
         >

--- a/src/app/talk/[talkId].tsx
+++ b/src/app/talk/[talkId].tsx
@@ -209,6 +209,7 @@ export default function TalkDetail() {
             {
               minHeight: drawerHeight,
               paddingBottom: insets.bottom + theme.space24,
+              paddingTop: theme.space24,
             },
           ]}
         >

--- a/src/app/talk/[talkId].tsx
+++ b/src/app/talk/[talkId].tsx
@@ -209,7 +209,7 @@ export default function TalkDetail() {
             {
               minHeight: drawerHeight,
               paddingBottom: insets.bottom + theme.space24,
-              paddingTop: theme.space24,
+              paddingTop: Platform.OS === "ios" ? theme.space24 : undefined,
             },
           ]}
         >


### PR DESCRIPTION
## Why

[ENG-17647 Align headline and text vertically in the layout](https://linear.app/expo/issue/ENG-17647/align-headline-and-text-vertically-in-the-layout)


| Before      | After |
| ----------- | ----------- |
|   <img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/6da71f9b-d7f3-403b-b5e4-ebefe40ab609" />  |  <img width="1716" height="1860" alt="image" src="https://github.com/user-attachments/assets/d17a8b85-206f-4444-9f1c-1986be93488a" />    |

| Before      | After |
| ----------- | ----------- |
| <img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/c7666121-e2a5-4cd0-a2c6-3ccfa3d7814d" />| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5d38fc40-c27a-4b34-b7f4-2545198e1d62" />|